### PR TITLE
Allocate right number of values in JZS prior

### DIFF
--- a/src/ZS.approx.null.np.c
+++ b/src/ZS.approx.null.np.c
@@ -100,7 +100,7 @@ double ZS_shrinkage(double R2, int n, int d, double rscale) {
   iwork = (int *) R_alloc((size_t) limit, sizeof(int));
   work = (double *) R_alloc((size_t) lenw, sizeof(double));
 
-  PROTECT(Rtheta = allocVector(REALSXP, 4));
+  PROTECT(Rtheta = allocVector(REALSXP, 5));
   REAL(Rtheta)[0] = R2;
   REAL(Rtheta)[1] = (double) n;
   REAL(Rtheta)[2] = (double) d;


### PR DESCRIPTION
On lines 104-108 `Rtheta` is filled with 5 elements, but only 4 were allocated on line 103. Changing the value to 5 fixes this. This change solves the sporadic error in JASP that I've previously emailed you about.
Best,
Don